### PR TITLE
New Feature

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -51,6 +51,14 @@ json:entries is a single tag, not a tag pair. Use channel:entries parameters to 
 #### json:entries Parameters
 
 See [channel:entries parameters](http://expressionengine.com/user_guide/modules/channel/parameters.html).
+	
+	output="images/output.json"
+
+Save the contents to an external file. Remember to set the permissions. Path is relative to the main index.php file and you do not need a slash at the start
+
+	refresh="240"
+
+Number in seconds on how often to refresh the output file. 
 
 ### json:members
 

--- a/system/expressionengine/third_party/json/pi.json.php
+++ b/system/expressionengine/third_party/json/pi.json.php
@@ -173,7 +173,48 @@ class Json
 			exit($data);
 		}
 		
+		// Output the file. status message is assigned to $output although 
+		// not displayed anywhere at the moment.
+		$output = $this->output_file($data);
+		
 		return $data;
+	}
+	
+	//Output returned data to file
+	public function output_file($data) 
+	{
+		$this->CI =& get_instance(); 
+		$this->CI->load->helper('file');
+		$this->CI->load->helper('array');
+		$this->CI->load->helper('date');
+		
+		$path = $this->EE->TMPL->fetch_param('output');
+		$refresh = $this->EE->TMPL->fetch_param('refresh');
+		
+		$now = now();
+		$file_info = get_file_info($path);
+		$date_created = element('date', $file_info);
+		
+		$difference = $now - $date_created;
+		
+		if ($difference > $refresh)
+		{
+			//rewrite the file
+			if ( ! write_file($path, $data))
+			{
+			     $return = 'Unable to write the file - Please check path permissions';
+			}
+			else 
+			{
+			     $return = 'File written!';
+			}
+		}
+		else
+		{
+			$return = "Using the cached version of the file";
+		}
+
+		return $return;	
 	}
 	
 	private function entries_channel_sql()
@@ -422,4 +463,4 @@ class Json
 	}
 }
 /* End of file pi.json.php */ 
-/* Location: ./system/expressionengine/third_party/json/pi.json.php */ 
+/* Location: ./system/expressionengine/third_party/json/pi.json.php */


### PR DESCRIPTION
I've added the ability to output data to an external file, within the json:entries function. It was something I specifically wanted for an upcoming project but I think it could be useful for some other people.

In the json:entries tag, it accepts two new parameters:

Path to the file | output="images/output.json"
   |
   | - Path relative to the main index.php file, doesn't need a slash at the start,
   | - add filename and extension, so you can output to .txt, .php etc. if required

Cache the file | refresh = "240"
   |
   | - Number of seconds until the plugin refreshes the file

I've also updated the readme to include these new parameters.
