### PR TITLE
Custom date formats

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,13 +36,19 @@ Set jsonp to yes to enable a JSONP response. You must also specify a valid callb
 
 Set a callback function for your JSONP request. Since query strings do not work out-of-the-box in EE, you may want to consider using a URL segment to specify your callback, ie. callback="{segment_3}", rather than the standard ?callback=foo method.
 
+	date_format="U"
+	
+Use a different date format. Note: always returns dates as string.
+
 ## Dates
 
-Date fields are in unix timestamp format, accurate to milliseconds. Use the Javascript Date object in combination with date field data:
+By default, the date fields are in unix timestamp format, accurate to milliseconds. Use the Javascript Date object in combination with date field data:
 
 	for (i in data) {
 		var entryDate = new Date(data[i].entry_date);
 	}
+
+If you require a different output format for the date fields, set the date_format= parameter. This uses the php date() function. common formats include "U" (unix timestamp in seconds), "c" (ISO 8601) or "Y-m-d H:i" (2011-12-24 19:06).
 
 ## json:entries
 

--- a/system/expressionengine/third_party/json/pi.json.php
+++ b/system/expressionengine/third_party/json/pi.json.php
@@ -22,6 +22,7 @@ class Json
 	protected $xhr = FALSE;
 	protected $fields = array();
 	protected $json_keys = array();
+	protected $date_format = FALSE;
 	protected $jsonp = FALSE;
 	protected $callback;
 	
@@ -193,17 +194,23 @@ class Json
 				//format dates as javascript unix time (in microseconds!)
 				if (isset($entry['entry_date']))
 				{
-					$entry['entry_date'] = (int) ($entry['entry_date'].'000');
+					$entry['entry_date'] = ($this->date_format) ? date($this->date_format, $entry['entry_date']) : (int) ($entry['entry_date'].'000');
 				}
 				
 				if (isset($entry['edit_date']))
 				{
-					$entry['edit_date'] = (int) (strtotime($entry['edit_date']).'000');
+					$entry['edit_date'] = strtotime($entry['edit_date']);
+					$entry['edit_date'] = ($this->date_format) ? date($this->date_format, $entry['edit_date']) : (int) ($entry['edit_date'].'000');
 				}
 				
 				if (isset($entry['expiration_date']))
 				{
-					$entry['expiration_date'] = ($entry['expiration_date']) ? (int) ($entry['expiration_date'].'000') : NULL;
+					if($entry['expiration_date'])
+					{
+						$entry['expiration_date'] = ($this->date_format) ? date($this->date_format, $entry['expiration_date']) : (int) ($entry['expiration_date'].'000');
+					}
+					else $entry['expiration_date'] = NULL;
+					
 				}
 				
 				foreach ($this->entries_custom_fields as &$field)
@@ -614,6 +621,8 @@ class Json
 		}
 		$this->fields = array_keys($this->json_keys);
 		
+		$this->date_format = $this->EE->TMPL->fetch_param('date_format', false);
+
 		$this->jsonp = $this->EE->TMPL->fetch_param('jsonp') === 'yes';
 		
 		$this->EE->load->library('jsonp');


### PR DESCRIPTION
Rob, you went the extra mile and made the default timestamps javascript-compatible. The problem is, some javascript developers did the same, and are also multiplying another thousand :-)

added date_format parameter to be able to override the default.
