### PR TITLE
Clean keys should return the whole arrays not one item :-)

### DIFF
--- a/system/expressionengine/third_party/json/pi.json.php
+++ b/system/expressionengine/third_party/json/pi.json.php
@@ -648,7 +648,7 @@ class Json
 	{
 		$this->EE->load->helper('inflector');
 		
-		foreach ($arrays as $array)
+		foreach ($arrays as &$array)
 		{
 			foreach ($array as $key => $value)
 			{
@@ -673,7 +673,7 @@ class Json
 			}
 		}
 		
-		return $array;
+		return $arrays;
 	}
 	
 	protected function date_format($date)


### PR DESCRIPTION
Rob, you left out that "by reference" 
(BTW a trick that i didn't really knew/used before. Learning from your code :-) )
foreach( $arrays as &$blah){}
