### PR TITLE
Fixed PHP_INT_MAX issue after casting date integer on a 32-bit system

### DIFF
--- a/system/expressionengine/third_party/json/pi.json.php
+++ b/system/expressionengine/third_party/json/pi.json.php
@@ -904,7 +904,7 @@ class Json
       return NULL;
     }
 
-    return ($this->date_format) ? date($this->date_format, $date) : (int) ($date.'000');
+    return ($this->date_format) ? date($this->date_format, $date) : $date * 1000;
   }
 
   protected function respond(array $response, $callback = NULL)


### PR DESCRIPTION
(int) ($date.'000') returns 2147483647 that is PHP_INT_MAX on a 32-bit system so that I removed integer casting.

For example, on a 32 bit system, it goes to the following.
$date = 1367129640;
(int) ($date.'000') -> 2147483647 (integer)
(int) $date.'000'   ->  "1367129640000" (string)
$date.'000'          ->  "1367129640000" (string)
$date \* 1000       ->  1367129640000 (double)

On a 64 bit system, this works as it is. 
