### PR TITLE
Allow {member_id} in member_id parameter to get logged in user

### DIFF
--- a/system/expressionengine/third_party/json/pi.json.php
+++ b/system/expressionengine/third_party/json/pi.json.php
@@ -955,15 +955,18 @@ class Json
       }
     }
 
-    // Parse parameters first so we don't interrupt query in progress with parse_globals()
-    $member_ids = ee()->TMPL->parse_globals(ee()->TMPL->fetch_param('member_id'));
-
     ee()->db->select(implode(', ', $select), FALSE)
             ->from('members m')
             ->join('member_data d', 'm.member_id = d.member_id');
 
-    if (strlen($member_ids) > 0)
+    if (ee()->TMPL->fetch_param('member_id'))
     {
+      if (ee()->TMPL->fetch_param('member_id') == 'CURRENT_USER' AND ee()->session->userdata['member_id'] != '0') {
+        $member_ids = ee()->session->userdata['member_id'];
+      } else {
+        $member_ids = ee()->TMPL->fetch_param('member_id');
+      }
+
       ee()->db->where_in('m.member_id', explode('|', $member_ids));
     }
     else if (ee()->TMPL->fetch_param('username'))


### PR DESCRIPTION
I was in a place where I needed to get the logged in user's member data, however, the {member_id} tag isn't being parsed and therefore returns no results. This allows you to do something like:

```
{exp:json:members member_id="{member_id}"}
```

Because of CI needing to run a query to parse global vars, I had to pull the parsing up before your query happens.
