### PR TITLE
Changed [] to array()

### DIFF
--- a/system/expressionengine/third_party/json/pi.json.php
+++ b/system/expressionengine/third_party/json/pi.json.php
@@ -527,7 +527,7 @@ class Json
 
   protected function entries_channel_files($entry_id, $field, $field_data, $entry)
   {
-    $this->entries_channel_files_data = [];
+    $this->entries_channel_files_data = array();
 
     $field_settings = unserialize(base64_decode($field['field_settings']));
     $field_settings = $field_settings['channel_files'];


### PR DESCRIPTION
New array shorthand [] only works with PHP 5.4+ so changed it to array()