### PR TITLE
Improved Wygwam support

### DIFF
--- a/system/expressionengine/third_party/json/pi.json.php
+++ b/system/expressionengine/third_party/json/pi.json.php
@@ -694,6 +694,10 @@ class Json
     return $field_data;
   }
 
+  protected function entries_wygwam($entry_id, $field, $field_data, $entry) {
+    return $this->entries_custom_field($entry_id, $field, $field_data, $entry);
+  }
+
   protected function entries_assets($entry_id, $field, $field_data, $entry)
   {
     $field_data = $this->entries_custom_field($entry_id, $field, $field_data, $entry);


### PR DESCRIPTION
Although I found that native file tags (like `{filedir_1}`) were being replaced without explicitly calling Wygwam’s pre_process method, Assets tags (like `{assets_699:http://domain.ext/file.png}`) were not. This fixes that.

(Should entries_custom_field be called for all custom field types? I wondered about adding that instead, but haven’t got the time to test for bugs elsewhere atm.)