### PR TITLE
Ensure that ee()->TMPL is not overwritten

### DIFF
--- a/system/expressionengine/third_party/json/pi.json.php
+++ b/system/expressionengine/third_party/json/pi.json.php
@@ -677,6 +677,7 @@ class Json
     {
       require_once PATH_THIRD.'json/libraries/Json_Template.php';
 
+      $ee_tmpl = ee()->TMPL;
       $template = new Json_Template();
 
       $field_data = ee()->api_channel_fields->apply('replace_tag', array($field_data, array(), $tagdata));
@@ -687,6 +688,7 @@ class Json
       }
 
       unset($template);
+      ee()->TMPL = $ee_tmpl;
     }
 
     ee()->load->remove_package_path(ee()->api_channel_fields->ft_paths[$field['field_type']]);


### PR DESCRIPTION
I posted a [comment about this](https://github.com/rsanchez/json/pull/60#issuecomment-345777479) yesterday and thought I might as well submit a PR with the changes I’ve made locally. This does feel like a bit of a bodge, but the issue seems to have affected quite a few people (my guess is it’s the source of all missing `tagparams` problems) and this is proving to be a reliable fix for me.